### PR TITLE
Remove uv add from tasks and hard code dev deps in pyproject.toml

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -29,12 +29,10 @@ py_version:
 _subdirectory: template
 
 _tasks:
-  - git init --initial-branch=main
-
   # Create initial commit with only README so that dynamic version lookup succeeds
   # Don't commit other files so that developer can modify before adding to repo
-  - git add README.md
-  - git commit -m "Initial commit"
-
-  # Use uv to add dev dependencies so that the latest versions are used.
-  - uv add --dev pytest ruff nox
+  - when: "{{ _copier_operation == 'copy' }}"
+    command: |
+      git init --initial-branch=main
+      git add README.md
+      git commit -m "Initial commit"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -14,8 +14,12 @@ dynamic = ["version"]
 dependencies = []
 
 [dependency-groups]
-    dev = []
-    
+dev = [
+    "nox>=2025.2.9",
+    "pytest>=8.3.5",
+    "ruff>=0.11.6",
+]
+
 [tool.ruff]
 per-file-ignores = { "__init__.py" = ["F401"] }
 


### PR DESCRIPTION
Removing `uv add` from copier tasks since it complicates updating of templates. Dev dependency versions are instead add directly to the pyproject.toml file. Users can manually run uv sync after creating or updating the template. Also ensures that the initial commit is only created on the copy command and not update.

Fixes #12 